### PR TITLE
Don't shift tooltips left

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -137,8 +137,6 @@
     -webkit-transition: all .1s ease;
     transition: all .1s ease;
     pointer-events: none;
-    -webkit-transform: translate(-50%, 0);
-    transform: translate(-50%, 0);
 }
 
 .chartjs-tooltip-key {


### PR DESCRIPTION
`transform: translate(-50%, 0);` was shifting the tooltips off the page for me on mobile. This is a quick fix removing that, which does affect desktop as well (tooltips not centered under the cursor), but with this change they are at least readable on both desktop/mobile. 